### PR TITLE
Make `rake-compiler` an explicit dev dependency

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -59,7 +59,7 @@ DEPENDENCIES
   dsp_blueprint_parser!
   pry (~> 0.14.0)
   rake (~> 13.0)
-  rake-compiler
+  rake-compiler (~> 1.0)
   rspec (~> 3.0)
   rspec-expectations (~> 3.10.1)
   rspec-its (~> 1.3.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -18,6 +18,8 @@ GEM
       method_source (~> 1.0)
     rainbow (3.0.0)
     rake (13.0.6)
+    rake-compiler (1.2.7)
+      rake
     regexp_parser (2.1.1)
     rexml (3.2.5)
     rspec (3.10.0)
@@ -57,6 +59,7 @@ DEPENDENCIES
   dsp_blueprint_parser!
   pry (~> 0.14.0)
   rake (~> 13.0)
+  rake-compiler
   rspec (~> 3.0)
   rspec-expectations (~> 3.10.1)
   rspec-its (~> 1.3.0)

--- a/README.md
+++ b/README.md
@@ -39,8 +39,6 @@ To install this gem onto your local machine, run `bundle exec rake install`. To 
 
 ## Contributing
 
-Running `rake compile` requires `gem install rake-compiler` to build the md5f extension.
-
 Bug reports and pull requests are welcome on GitHub at https://github.com/LRFalk01/dsp_blueprint_parser.
 
 ## License

--- a/bin/setup
+++ b/bin/setup
@@ -6,3 +6,4 @@ set -vx
 bundle install
 
 # Do any other automated setup that you need to do here
+bundle exec rake compile

--- a/dsp_blueprint_parser.gemspec
+++ b/dsp_blueprint_parser.gemspec
@@ -34,7 +34,7 @@ Gem::Specification.new do |spec|
 
   # For more information and examples about making a new gem, checkout our
   # guide at: https://bundler.io/guides/creating_gem.html
-  spec.add_development_dependency "rake-compiler"
+  spec.add_development_dependency "rake-compiler", "~> 1.0"
 
   spec.extensions = %w[ext/md5f/extconf.rb]
 end

--- a/dsp_blueprint_parser.gemspec
+++ b/dsp_blueprint_parser.gemspec
@@ -34,6 +34,7 @@ Gem::Specification.new do |spec|
 
   # For more information and examples about making a new gem, checkout our
   # guide at: https://bundler.io/guides/creating_gem.html
+  spec.add_development_dependency "rake-compiler"
 
   spec.extensions = %w[ext/md5f/extconf.rb]
 end


### PR DESCRIPTION
Making `rake-compiler` an explicit development dependency of the gem gets `rake-compiler` installed during `bundle install` and also means that we can run `rake compile` as part of `bin/setup`.

Since telling folks to install `rake-compiler` in the README isn't required with this PR anymore, I removed that bit from the README. `rake spec` didn't work for me without installing `rake-compiler` and running `rake compile` which is what prompted this change.

This should be merged along with #3 since I built them on top of each other but split out the changes to make it easier to review.
