### PR TITLE
Fix compiler warnings and spec crash

### DIFF
--- a/ext/md5f/md5f.c
+++ b/ext/md5f/md5f.c
@@ -1,4 +1,4 @@
-#include<stdio.h> // define the header file  
+#include <stdio.h> // define the header file
 #include <stdlib.h>
 #include <string.h>
 #include "ruby.h"
@@ -26,7 +26,7 @@ const int S43 = 15;
 const int S44 = 21;
 
 // ugly, I know
-uint ArrayLength = 0;
+size_t ArrayLength = 0;
 
 uint F(uint x, uint y, uint z)
 {
@@ -88,12 +88,12 @@ void MD5_Init()
     D = 271734598U;
 }
 
-uint * MD5_Append(unsigned char input[], size_t length)
+uint * MD5_Append(char* input, size_t length)
 {
-    int num1 = 1;
-    int num2 = length % 64;
-    int num3;
-    int num4 = 0;
+    size_t num1 = 1;
+    size_t num2 = length % 64;
+    size_t num3;
+    size_t num4 = 0;
     if (num2 < 56)
     {
         num3 = 55 - num2;
@@ -124,7 +124,7 @@ uint * MD5_Append(unsigned char input[], size_t length)
         arrayList[position++] = (unsigned char) 128;
     }
 
-    for (int index = 0; index < num3; ++index)
+    for (size_t index = 0; index < num3; ++index)
     {
         arrayList[position++] = (unsigned char) 0;
     }
@@ -148,7 +148,7 @@ uint * MD5_Append(unsigned char input[], size_t length)
     arrayList[position++] = num13;
 
     ArrayLength = num4 / 4;
-    uint *numArray = calloc(ArrayLength, sizeof(uint));
+    uint *numArray = calloc(ArrayLength, sizeof(size_t));
     long index1 = 0;
     long index2 = 0;
     for (; index1 < (long) num4; index1 += 4)
@@ -162,7 +162,7 @@ uint * MD5_Append(unsigned char input[], size_t length)
 
 void MD5_Trasform(uint x[])
 {
-    for (int index = 0; index < ArrayLength; index += 16)
+    for (size_t index = 0; index < ArrayLength; index += 16)
     {
         uint a = A;
         uint b = B;
@@ -239,7 +239,7 @@ void MD5_Trasform(uint x[])
     }
 }
 
-unsigned char * MD5_Array(unsigned char input[], long length)
+unsigned char * MD5_Array(char* input, long length)
 {
     MD5_Init();
     uint *append = MD5_Append(input, length);
@@ -264,12 +264,12 @@ unsigned char * MD5_Array(unsigned char input[], long length)
     return numArray2;
 }
 
-unsigned char * ArrayToHexString(unsigned char input[])
+char * ArrayToHexString(unsigned char * input)
 {
-    size_t length = 16;
-    unsigned char *result = calloc(length * 2, sizeof(unsigned char));
+    int length = 16;
+    char *result = calloc((length * 2) + 1, sizeof(char));
 
-    for (size_t i = 0; i < length; i++)
+    for (int i = 0; i < length; i++)
     {
         sprintf(result+2*i, "%.2X", input[i]);
     }
@@ -277,10 +277,10 @@ unsigned char * ArrayToHexString(unsigned char input[])
     return result;
 }
 
-unsigned char * Compute(unsigned char message[], long length)
+char * Compute(char* message, long length)
 {
     unsigned char * data = MD5_Array(message, length);
-    unsigned char * result = ArrayToHexString(data);
+    char * result = ArrayToHexString(data);
 
     free(data);
     return result;
@@ -291,10 +291,10 @@ VALUE rb_compute(VALUE self, VALUE str) {
         return Qnil;
     }
 
-    unsigned char *data = StringValuePtr(str);
+    char *data = StringValuePtr(str);
     long strLength = RSTRING_LEN(str);
 
-    unsigned char *hex = Compute(data, strLength);
+    char *hex = Compute(data, strLength);
 
     VALUE result = rb_str_new(hex, 32);
     free(hex);


### PR DESCRIPTION
rb_str_new takes a `const char *` as its first parameter. The compiler will do the conversion from `char *` to `const char *` for us, no problem. However, most of the code was using `unsigned char *`, which the compiler did not like at all.

`rake compile` output before this PR:
```bash
$ rake clean ; rake compile
mkdir -p tmp/x86_64-darwin23/md5f/3.0.7
cd tmp/x86_64-darwin23/md5f/3.0.7
/Users/mattr-/.local/share/mise/installs/ruby/3.0.7/bin/ruby -I. ../../../../ext/md5f/extconf.rb
creating Makefile
cd -
cd tmp/x86_64-darwin23/md5f/3.0.7
/usr/bin/make
compiling ../../../../ext/md5f/md5f.c
../../../../ext/md5f/md5f.c:100:30: warning: implicit conversion loses integer precision: 'size_t' (aka 'unsigned long') to 'int' [-Wshorten-64-to-32]
        num4 = length - num2 + 64;
             ~ ~~~~~~~~~~~~~~^~~~
../../../../ext/md5f/md5f.c:106:27: warning: implicit conversion loses integer precision: 'size_t' (aka 'unsigned long') to 'int' [-Wshorten-64-to-32]
        num4 = length + 8 + 64;
             ~ ~~~~~~~~~~~^~~~
../../../../ext/md5f/md5f.c:111:35: warning: implicit conversion loses integer precision: 'size_t' (aka 'unsigned long') to 'int' [-Wshorten-64-to-32]
        num4 = length + 64 - num2 + 64;
             ~ ~~~~~~~~~~~~~~~~~~~^~~~
../../../../ext/md5f/md5f.c:165:31: warning: comparison of integers of different signs: 'int' and 'uint' (aka 'unsigned int') [-Wsign-compare]
    for (int index = 0; index < ArrayLength; index += 16)
                        ~~~~~ ^ ~~~~~~~~~~~
../../../../ext/md5f/md5f.c:274:17: warning: passing 'unsigned char *' to parameter of type 'char *' converts between pointers to integer types where one is of the unique plain 'char' type and the other is not [-Wpointer-sign]
        sprintf(result+2*i, "%.2X", input[i]);
                ^~~~~~~~~~
/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/secure/_stdio.h:47:28: note: expanded from macro 'sprintf'
  __builtin___sprintf_chk (str, 0, __darwin_obsz(str), __VA_ARGS__)
                           ^~~
../../../../ext/md5f/md5f.c:294:20: warning: initializing 'unsigned char *' with an expression of type 'char *' converts between pointers to integer types where one is of the unique plain 'char' type and the other is not [-Wpointer-sign]
    unsigned char *data = StringValuePtr(str);
                   ^      ~~~~~~~~~~~~~~~~~~~
../../../../ext/md5f/md5f.c:299:20: warning: passing 'unsigned char *' to parameter of type 'const char *' converts between pointers to integer types where one is of the unique plain 'char' type and the other is not [-Wpointer-sign]
    VALUE result = rb_str_new(hex, 32);
                   ^~~~~~~~~~~~~~~~~~~
/Users/mattr-/.local/share/mise/installs/ruby/3.0.7/include/ruby-3.0.0/ruby/internal/intern/string.h:217:20: note: expanded from macro 'rb_str_new'
      rb_str_new) ((str), (len)))
                   ^~~~~
7 warnings generated.
linking shared-object dsp_blueprint_parser/md5f.bundle
ld: warning: ignoring duplicate libraries: '-lruby.3.0'
cd -
mkdir -p tmp/x86_64-darwin23/stage/lib
/usr/bin/make install sitearchdir=../../../../lib sitelibdir=../../../../lib target_prefix=
/usr/bin/install -c -m 0755 md5f.bundle ../../../../lib
cp tmp/x86_64-darwin23/md5f/3.0.7/md5f.bundle tmp/x86_64-darwin23/stage/lib/md5f.bundle
```

`rake compile` output after this PR:
```bash
$ rake clean ; rake compile
mkdir -p tmp/x86_64-darwin23/md5f/3.0.7
cd tmp/x86_64-darwin23/md5f/3.0.7
/Users/mattr-/.local/share/mise/installs/ruby/3.0.7/bin/ruby -I. ../../../../ext/md5f/extconf.rb
creating Makefile
cd -
cd tmp/x86_64-darwin23/md5f/3.0.7
/usr/bin/make
compiling ../../../../ext/md5f/md5f.c
linking shared-object dsp_blueprint_parser/md5f.bundle
ld: warning: ignoring duplicate libraries: '-lruby.3.0'
cd -
mkdir -p tmp/x86_64-darwin23/stage/lib
/usr/bin/make install sitearchdir=../../../../lib sitelibdir=../../../../lib target_prefix=
/usr/bin/install -c -m 0755 md5f.bundle ../../../../lib
cp tmp/x86_64-darwin23/md5f/3.0.7/md5f.bundle tmp/x86_64-darwin23/stage/lib/md5f.bundle

```

Before this change, running `rake spec` would crash on my intel mac at the end of the suite like so:
```
DspBlueprintParser
/Users/mattr-/Code/LRFalk01/DSP-Blueprint-Parser/lib/dsp_blueprint_parser.rb:39: [BUG] Illegal instruction at 0x00007ff80d2ffe1b
ruby 3.0.7p220 (2024-04-23 revision 724a071175) [x86_64-darwin23]
```

with a very large stacktrace and crash report to go with it. After these changes, the crash is gone and the suite runs cleanly! :tada: