### PR TITLE
Version Bump 0.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## [Unreleased]
 
+## [0.2.2] 2025-12-22
+
+- Quit including `.so` file in published gem.
+
 ## [0.2.1] 2025-12-22
 
 - Version bump to fix published gem.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    dsp_blueprint_parser (0.2.1)
+    dsp_blueprint_parser (0.2.2)
 
 GEM
   remote: https://rubygems.org/

--- a/lib/dsp_blueprint_parser/version.rb
+++ b/lib/dsp_blueprint_parser/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module DspBlueprintParser
-  VERSION = '0.2.1'
+  VERSION = '0.2.2'
 end


### PR DESCRIPTION
Quit including `.so` file in the published gem.